### PR TITLE
Add renovate to notify about new dependency versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "branch",
-      "additionalBranchPrefix": "{{parentDir}}-"
+      "automerge": false
     },
   ]
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -17,20 +17,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^friendly_captcha\/widgets.py$"],
-      "matchStrings": ["(?<=friendly-challenge@)<currentValue>(?=/)"],
-      "depNameTemplate": "unpkg",
-      "versioningTemplate": "semver-coerced",
-      "datasourceTemplate": "custom.unpkg"
+      "fileMatch": ["(^|/)friendly_captcha/widgets.py"],
+      "matchStrings": ["(?<=friendly-challenge@)(?<currentValue>.*?)(?=/)"],
+      "depNameTemplate": "friendly-challenge",
+      "datasourceTemplate": "npm"
     }
   ],
-  "customDatasources": {
-    "unpkg": {
-      "defaultRegistryUrlTemplate": "https://unpkg.com/friendly-challenge@latest/package.json",
-      "format": "json",
-      "transformTemplates": [
-        "{\"releases\":[{\"version\": $$.(version),\"sourceUrl\": $$.(repository),\"changelogUrl\":$join([\"https://docs.friendlycaptcha.com/#/changelog?id=_/\",version)}],\"sourceUrl\": $$.(repository),\"changelogUrl\": \"https://docs.friendlycaptcha.com/#/changelog\",\"homepage\": \"https://friendlycaptcha.com/\"}"
-      ]
-    }
-  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "customType": "regex",
       "fileMatch": ["(^|/)friendly_captcha/widgets.py$"],
-      "matchStrings": ["(?<=com\\/)(?<depName>.*?)\\@(?<currentValue>.*?)(?=\\/)"],
+      "matchStrings": [".*com\\/(?<depName>.*?)\\@(?<currentValue>.*)\\/"],
       "datasourceTemplate": "npm"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": false
-    },
+    }
   ]
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": false
     }
-  ]
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "customType": "regex",
       "fileMatch": ["(^|/)friendly_captcha/widgets.py$"],
-      "matchStrings": ["(?<=com\\/)(?<depName>.*?)\\@(?<currentValue>.*?)(?=/)"],
+      "matchStrings": ["(?<=com\\/)(?<depName>.*?)\\@(?<currentValue>.*?)(?=\\/)"],
       "datasourceTemplate": "npm"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "customType": "regex",
       "fileMatch": ["(^|/)friendly_captcha/widgets.py$"],
-      "matchStrings": ["(?<=com/)(?<depName>.*?)@(?<currentValue>.*?)(?=/)"],
+      "matchStrings": ["(?<=com\\/)(?<depName>.*?)\\@(?<currentValue>.*?)(?=/)"],
       "datasourceTemplate": "npm"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommits",
+    "config:recommended"
   ],
   "labels": ["dependency"],
   "platformAutomerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
   ],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
-  "platformAutomerge": true,
-  "forkProcessing": "enabled",
+  "platformAutomerge": true
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits"
   ],
   "platformAutomerge": true,
   "forkProcessing": "enabled",

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,9 @@
   "extends": [
     "config:recommended"
   ],
-  "forkProcessing": "enabled",
   "labels": ["dependency"],
   "platformAutomerge": true,
+  "forkProcessing": "enabled",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": ["dependency"],
   "platformAutomerge": true,
   "forkProcessing": "enabled",
+  "includeForks": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
@@ -15,7 +16,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)friendly_captcha\\/widgets.py$"],
+      "fileMatch": ["(^|/)friendly_captcha/widgets.py$"],
       "matchStrings": ["(?<=com/)(?<depName>.*?)@(?<currentValue>.*?)(?=/)"],
       "datasourceTemplate": "npm"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
-  "platformAutomerge": true
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "labels": ["dependency"],
   "platformAutomerge": true,
   "forkProcessing": "enabled",
   "includeForks": true,

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "includeForks": true,
   "labels": ["dependency"],
   "platformAutomerge": true,
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:base"
   ],
   "labels": ["dependency"],
   "platformAutomerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "includeForks": true,
+  "forkProcessing": "enabled",
   "labels": ["dependency"],
   "platformAutomerge": true,
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["widgets.py"],
+      "fileMatch": ["^friendly_captcha\/widgets.py$"],
       "matchStrings": ["(?<=friendly-challenge@)<currentValue>(?=/)"],
       "depNameTemplate": "unpkg",
       "versioningTemplate": "semver-coerced",

--- a/renovate.json
+++ b/renovate.json
@@ -14,9 +14,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)friendly_captcha/widgets.py"],
-      "matchStrings": ["(?<=friendly-challenge@)(?<currentValue>.*?)(?=/)"],
-      "depNameTemplate": "friendly-challenge",
+      "fileMatch": ["(^|/)friendly_captcha\\/widgets.py$"],
+      "matchStrings": ["(?<=com/)(?<depName>.*?)@(?<currentValue>.*?)(?=/)"],
       "datasourceTemplate": "npm"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,5 @@
       "matchStrings": ["(?<=com/)(?<depName>.*?)@(?<currentValue>.*?)(?=/)"],
       "datasourceTemplate": "npm"
     }
-  ],
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+  ],
+  "labels": ["dependency"],
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch",
+      "additionalBranchPrefix": "{{parentDir}}-"
+    },
+  ]
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["widgets.py"],
+      "matchStrings": ["(?<=friendly-challenge@)<currentValue>(?=/)"],
+      "depNameTemplate": "unpkg",
+      "versioningTemplate": "semver-coerced",
+      "datasourceTemplate": "custom.unpkg"
+    }
+  ],
+  "customDatasources": {
+    "unpkg": {
+      "defaultRegistryUrlTemplate": "https://unpkg.com/friendly-challenge@latest/package.json",
+      "format": "json",
+      "transformTemplates": [
+        "{\"releases\":[{\"version\": $$.(version),\"sourceUrl\": $$.(repository),\"changelogUrl\":$join([\"https://docs.friendlycaptcha.com/#/changelog?id=_/\",version)}],\"sourceUrl\": $$.(repository),\"changelogUrl\": \"https://docs.friendlycaptcha.com/#/changelog\",\"homepage\": \"https://friendlycaptcha.com/\"}"
+      ]
+    }
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:recommended",
     ":semanticCommits"
   ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
   "platformAutomerge": true,
   "forkProcessing": "enabled",
   "includeForks": true,

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   "dependencyDashboardTitle": "Dependency Dashboard",
   "platformAutomerge": true,
   "forkProcessing": "enabled",
-  "includeForks": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],


### PR DESCRIPTION
This PR adds a renovate config that notifies about new versions for dependencies such as friendly-widget (friendlycaptcha).

With renovate enabled for this repo, the renovate bot will scrape the files in this repo for dependencies and will automatically search for new versions for those.

If new versions are found, renovate will create pull requests for those:
![image](https://github.com/christianwgd/django-friendly-captcha/assets/27567533/24d4df49-33d3-4faf-a9fb-0e9b4d7da677)

A dashboard issue will also give you a a overview about all detected dependencies:
![image](https://github.com/christianwgd/django-friendly-captcha/assets/27567533/8e60d8c4-3e20-4ad1-9496-148eac4fb121)

To install renovate on github see the onboarding docs: https://github.com/renovatebot/renovate/blob/main/docs/usage/getting-started/installing-onboarding.md