### PR TITLE
Fix v2 integration

### DIFF
--- a/friendly_captcha/fields.py
+++ b/friendly_captcha/fields.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext_lazy as _
 
 from friendly_captcha.utils import (
     get_captcha_version,
-    get_verification_headers,
     get_verification_payload,
     get_verification_url,
 )
@@ -35,22 +34,17 @@ class FrcCaptchaField(forms.CharField):
         captcha_sitekey = getattr(settings, 'FRC_CAPTCHA_SITE_KEY', None)
         captcha_verification_url = get_verification_url()
         captcha_version = get_captcha_version()
-        captcha_secret = getattr(settings, 'FRC_CAPTCHA_SECRET', None)
         captcha_api_key = getattr(settings, 'FRC_CAPTCHA_API_KEY', None)
-        if captcha_version == 2:
-            captcha_ready = bool(captcha_verification_url and captcha_api_key)
-        else:
-            captcha_ready = bool(captcha_sitekey and captcha_secret and captcha_verification_url)
+       
+        captcha_ready = bool(captcha_sitekey and captcha_api_key and captcha_verification_url)
 
         if captcha_ready:
             payload = get_verification_payload(value)
+            payload['sitekey'] = captcha_sitekey
             if captcha_version == 2:
-                if captcha_sitekey:
-                    payload['sitekey'] = captcha_sitekey
-                headers = get_verification_headers()
+                headers = {'X-API-Key': captcha_api_key}
             else:
-                payload['secret'] = captcha_secret
-                payload['sitekey'] = captcha_sitekey
+                payload['secret'] = captcha_api_key
                 headers = {}
 
             captcha_response = requests.post(
@@ -65,8 +59,10 @@ class FrcCaptchaField(forms.CharField):
                     logger.info('Captcha failed validation %s', validation)
                 else:
                     logger.info('Captcha validation success')
-                    clean_value = True
+                    clean_value = True                
+
             else:  # Unverified response
+                logger.info('Captcha failed validation (code %s) %s', captcha_response.status_code, captcha_response.text)
                 accept_unverified = getattr(settings, 'FRC_CAPTCHA_ACCEPT_UNVERIFIED', False)
                 if accept_unverified:
                     logger.info(

--- a/friendly_captcha/tests.py
+++ b/friendly_captcha/tests.py
@@ -4,9 +4,10 @@ from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 from unittest.mock import patch, MagicMock
 from friendly_captcha.utils import (
+    get_captcha_endpoint,
     get_captcha_version,
+    get_start_mode,
     get_verification_url,
-    get_verification_headers,
     get_widget_script_urls,
 )
 from friendly_captcha.fields import FrcCaptchaField
@@ -30,11 +31,9 @@ django.setup()
 
 class FrcCaptchaUtilsTest(TestCase):
 
-    @override_settings(
-        FRC_CAPTCHA_API_KEY='some-api-key', FRC_CAPTCHA_SECRET='some-secret'  # noqa: S106
-    )
+    @override_settings()
     def test_get_captcha_version_default(self):
-        self.assertEqual(get_captcha_version(), 2)
+        self.assertEqual(get_captcha_version(), 1)
 
     @override_settings(FRC_CAPTCHA_VERSION='1')
     def test_get_captcha_version_v1(self):
@@ -44,30 +43,35 @@ class FrcCaptchaUtilsTest(TestCase):
     def test_get_captcha_version_v2(self):
         self.assertEqual(get_captcha_version(), 2)
 
-    def test_get_verification_url_default(self):
-        self.assertEqual(get_verification_url(), 'https://api.friendlycaptcha.com/api/v1/siteverify')
+    @override_settings()
+    def test_get_captcha_endpoint_default(self):
+        self.assertEqual(get_captcha_endpoint(), 'https://api.friendlycaptcha.com/api/v1/puzzle')
 
-    @override_settings(FRC_CAPTCHA_VERIFICATION_URL='https://api.friendlycaptcha.com/api/v1/siteverify')
-    def test_get_verification_url_v1(self):
+    @override_settings(FRC_CAPTCHA_VERSION=2, FRC_CAPTCHA_ENDPOINT='eu')
+    def test_get_captcha_endpoint_eu(self):
+        self.assertEqual(get_captcha_endpoint(), 'eu')
+
+    @override_settings()
+    def test_get_verification_url_default(self):
         self.assertEqual(get_verification_url(), 'https://api.friendlycaptcha.com/api/v1/siteverify')
 
     @override_settings(FRC_CAPTCHA_VERSION=2)
     def test_get_verification_url_v2(self):
         self.assertEqual(get_verification_url(), 'https://global.frcapi.com/api/v2/captcha/siteverify')
 
-    def test_get_verification_headers_default(self):
-        self.assertEqual(get_verification_headers(), {})
+    @override_settings(FRC_CAPTCHA_VERSION=2, FRC_CAPTCHA_ENDPOINT='eu')
+    def test_get_verification_url_v2_eu(self):
+        self.assertEqual(get_verification_url(), 'https://eu.frcapi.com/api/v2/captcha/siteverify')
 
-    @override_settings(FRC_CAPTCHA_VERSION=2)
-    def test_get_verification_headers_v2(self):
-        self.assertEqual(get_verification_headers(), {})
+    @override_settings()
+    def test_get_start_mode_default(self):
+        self.assertEqual(get_start_mode(), 'focus')
 
-    @override_settings(
-        FRC_CAPTCHA_API_KEY='some-api-key', FRC_CAPTCHA_SECRET='some-secret'  # noqa: S106
-    )
-    def test_get_verification_headers_v1(self):
-        self.assertEqual(get_verification_headers(), {'X-API-Key': 'some-api-key'})
+    @override_settings(FRC_CAPTCHA_START_MODE='none')
+    def test_get_start_mode_none(self):
+        self.assertEqual(get_start_mode(), 'none')
 
+    @override_settings()
     def test_widget_script_urls_default(self):
         self.assertEqual(
             get_widget_script_urls(),
@@ -81,7 +85,7 @@ class FrcCaptchaUtilsTest(TestCase):
         FRC_WIDGET_MODULE_JS='https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk/site.min.js',
         FRC_WIDGET_JS='https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk/site.compat.min.js',
     )
-    def test_widget_script_urls_v1(self):
+    def test_widget_script_urls_override(self):
         self.assertEqual(
             get_widget_script_urls(),
             (
@@ -128,9 +132,9 @@ class FrcCaptchaWidgetTest(TestCase):
 
 class FrcCaptchaWidgetV2Test(TestCase):
     @override_settings(
+        FRC_CAPTCHA_VERSION=2,
         FRC_CAPTCHA_SITE_KEY='test-site-key',
         FRC_CAPTCHA_API_KEY='test-api-key',
-        FRC_CAPTCHA_VERIFICATION_URL='https://global.frcapi.com/api/v2/captcha/siteverify',
         LANGUAGE_CODE='en',
     )
     def test_render_v2(self):
@@ -164,18 +168,7 @@ class FrcCaptchaFieldTest(TestCase):
 
     @override_settings(
         FRC_CAPTCHA_ACCEPT_UNVERIFIED=True,
-        FRC_CAPTCHA_VERIFICATION_URL='https://example.com/verify',
-        FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_SECRET='some-secret',  # noqa: S106
-    )
-    def test_clean_accept_unverified_v1(self):
-        field = FrcCaptchaField()
-        result = field.clean('some-value')
-        self.assertTrue(result)
-
-    @override_settings(
-        FRC_CAPTCHA_ACCEPT_UNVERIFIED=True,
-        FRC_CAPTCHA_VERIFICATION_URL='https://example.com/verify',
+        FRC_CAPTCHA_VERSION=2,
         FRC_CAPTCHA_SITE_KEY='test-site-key',
         FRC_CAPTCHA_API_KEY='test-api-key',
     )
@@ -186,11 +179,12 @@ class FrcCaptchaFieldTest(TestCase):
 
     @patch('friendly_captcha.fields.requests.post')
     @override_settings(
-        FRC_CAPTCHA_SECRET='test-secret',  # noqa: S106 Possible hardcoded password
+        FRC_CAPTCHA_VERSION=2,
+        FRC_CAPTCHA_API_KEY='test-api-key',
         FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_VERIFICATION_URL='http://test-url.com'
+        FRC_CAPTCHA_ENDPOINT='eu',
     )
-    def test_clean_verification_success(self, mock_post):
+    def test_clean_verification_success_v2_eu_endpoint(self, mock_post):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {'success': True}
@@ -200,15 +194,16 @@ class FrcCaptchaFieldTest(TestCase):
         result = field.clean('some-value')
         self.assertTrue(result)
         mock_post.assert_called_once()
-        self.assertEqual(mock_post.call_args.kwargs['data']['solution'], 'some-value')
-        self.assertEqual(mock_post.call_args.kwargs['data']['secret'], 'test-secret')
+        self.assertEqual(mock_post.call_args.args[0], 'https://eu.frcapi.com/api/v2/captcha/siteverify')
+        self.assertEqual(mock_post.call_args.kwargs['data']['response'], 'some-value')
         self.assertEqual(mock_post.call_args.kwargs['data']['sitekey'], 'test-site-key')
+        self.assertEqual(mock_post.call_args.kwargs['headers']['X-API-Key'], 'test-api-key')
 
     @patch('friendly_captcha.fields.requests.post')
     @override_settings(
+        FRC_CAPTCHA_VERSION=2,
         FRC_CAPTCHA_API_KEY='test-api-key',
         FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_VERIFICATION_URL='https://global.frcapi.com/api/v2/captcha/siteverify'
     )
     def test_clean_v2_verification_fail(self, mock_post):
         mock_response = MagicMock()
@@ -225,9 +220,9 @@ class FrcCaptchaFieldTest(TestCase):
 
     @patch('friendly_captcha.fields.requests.post')
     @override_settings(
-        FRC_CAPTCHA_SECRET='test-secret',  # noqa: S106 Possible hardcoded password
+        FRC_CAPTCHA_VERSION=2,
+        FRC_CAPTCHA_API_KEY='test-api-key',
         FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_VERIFICATION_URL='http://test-url.com'
     )
     def test_clean_verification_fail_not_200(self, mock_post):
         mock_response = MagicMock()
@@ -239,50 +234,20 @@ class FrcCaptchaFieldTest(TestCase):
         with pytest.raises(ValidationError):
             field.clean('some-value')
 
-    @patch('friendly_captcha.fields.requests.post')
     @override_settings(
-        FRC_CAPTCHA_API_KEY='test-api-key',
+        FRC_CAPTCHA_VERSION=2,
         FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_VERIFICATION_URL='https://global.frcapi.com/api/v2/captcha/siteverify',
-    )
-    def test_clean_verification_success_v2(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {'success': True}
-        mock_post.return_value = mock_response
-
-        field = FrcCaptchaField()
-        result = field.clean('some-value')
-        self.assertTrue(result)
-        mock_post.assert_called_once()
-        self.assertEqual(mock_post.call_args.kwargs['data']['response'], 'some-value')
-        self.assertEqual(mock_post.call_args.kwargs['data']['sitekey'], 'test-site-key')
-        self.assertEqual(mock_post.call_args.kwargs['headers']['X-API-Key'], 'test-api-key')
-
-    @override_settings(
-        FRC_CAPTCHA_SITE_KEY='test-site-key',
-        FRC_CAPTCHA_VERIFICATION_URL='https://global.frcapi.com/api/v2/captcha/siteverify',
     )
     def test_clean_v2_requires_api_key(self):
         field = FrcCaptchaField()
         with pytest.raises(ValidationError):
             field.clean('some-value')
 
-    @patch('friendly_captcha.fields.requests.post')
     @override_settings(
-        FRC_CAPTCHA_API_KEY='test-api-key',
-        FRC_CAPTCHA_VERIFICATION_URL='https://global.frcapi.com/api/v2/captcha/siteverify',
-    )
-    def test_clean_verification_success_v2_without_sitekey(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {'success': True}
-        mock_post.return_value = mock_response
-
+    FRC_CAPTCHA_VERSION=2,
+    FRC_CAPTCHA_API_KEY='test-api-key',
+)
+    def test_clean_verification_requires_sitekey_v2(self):
         field = FrcCaptchaField()
-        result = field.clean('some-value')
-        self.assertTrue(result)
-        mock_post.assert_called_once()
-        self.assertEqual(mock_post.call_args.kwargs['data']['response'], 'some-value')
-        self.assertNotIn('sitekey', mock_post.call_args.kwargs['data'])
-        self.assertEqual(mock_post.call_args.kwargs['headers']['X-API-Key'], 'test-api-key')
+        with pytest.raises(ValidationError):
+            field.clean('some-value')

--- a/friendly_captcha/utils.py
+++ b/friendly_captcha/utils.py
@@ -1,10 +1,14 @@
 from django.conf import settings
 
 V1_VERIFICATION_URL = 'https://api.friendlycaptcha.com/api/v1/siteverify'
+V1_VERIFICATION_URL_EU = 'https://eu-api.friendlycaptcha.eu/api/v1/siteverify'
 V2_VERIFICATION_URL = 'https://global.frcapi.com/api/v2/captcha/siteverify'
+V2_VERIFICATION_URL_EU = 'https://eu.frcapi.com/api/v2/captcha/siteverify'
 
 V1_WIDGET_MODULE_JS = 'https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.20/widget.module.min.js'
 V1_WIDGET_JS = 'https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.20/widget.min.js'
+V1_WIDGET_ENDPOINT_EU = 'https://eu-api.friendlycaptcha.eu/api/v1/puzzle'
+V1_WIDGET_ENDPOINT_GLOBAL = 'https://api.friendlycaptcha.com/api/v1/puzzle'
 
 V2_WIDGET_MODULE_JS = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk/site.min.js'
 V2_WIDGET_JS = 'https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk/site.compat.min.js'
@@ -16,39 +20,41 @@ def get_captcha_version():
         return 1
     if configured_version in (2, '2'):
         return 2
+    return 1  # Default to version 1 if not specified
 
-    verification_url = getattr(settings, 'FRC_CAPTCHA_VERIFICATION_URL', None)
-    if verification_url and '/api/v2/' in verification_url:
-        return 2
-
-    if getattr(settings, 'FRC_CAPTCHA_API_KEY', None):
-        return 2
-
-    return 1
-
+def get_captcha_endpoint():
+    configured_endpoint = getattr(settings, 'FRC_CAPTCHA_ENDPOINT', None)
+    if get_captcha_version() == 2: 
+        if configured_endpoint == 'eu':
+            return configured_endpoint
+        else: 
+            return 'global'
+    else: 
+        if configured_endpoint == 'eu':
+            return V1_WIDGET_ENDPOINT_EU
+        else:
+            return V1_WIDGET_ENDPOINT_GLOBAL
 
 def get_verification_url():
-    configured_url = getattr(settings, 'FRC_CAPTCHA_VERIFICATION_URL', None)
-    if configured_url:
-        return configured_url
     if get_captcha_version() == 2:
+        if get_captcha_endpoint() == 'eu':
+            return V2_VERIFICATION_URL_EU
         return V2_VERIFICATION_URL
-    return V1_VERIFICATION_URL
+    else:
+        if get_captcha_endpoint() == 'eu':
+            return V1_VERIFICATION_URL_EU
+        return V1_VERIFICATION_URL
 
+def get_start_mode():
+    configured_start_mode = getattr(settings, 'FRC_CAPTCHA_START_MODE', None)
+    if configured_start_mode in ('auto', 'focus', 'none'):
+        return configured_start_mode
+    return 'focus'
 
 def get_verification_payload(value):
     if get_captcha_version() == 2:
         return {'response': value}
     return {'solution': value}
-
-
-def get_verification_headers():
-    if get_captcha_version() != 2:
-        return {}
-
-    api_key = getattr(settings, 'FRC_CAPTCHA_API_KEY', None)
-    return {'X-API-Key': api_key} if api_key else {}
-
 
 def get_widget_script_urls():
     module_js = getattr(settings, 'FRC_WIDGET_MODULE_JS', None)

--- a/friendly_captcha/widgets.py
+++ b/friendly_captcha/widgets.py
@@ -5,7 +5,7 @@ from django.utils.html import format_html
 from django.forms.utils import flatatt
 from django.utils.safestring import mark_safe
 
-from friendly_captcha.utils import get_widget_field_name_attr, get_widget_language_attr, get_widget_script_urls
+from friendly_captcha.utils import get_widget_field_name_attr, get_widget_language_attr, get_widget_script_urls, get_captcha_version, get_captcha_endpoint, get_start_mode
 
 
 class FrcCaptchaWidget(Widget):
@@ -18,8 +18,13 @@ class FrcCaptchaWidget(Widget):
     def render(self, name, value, attrs=None, renderer=None):
         if attrs is None:
             attrs = {}
-        attrs[get_widget_language_attr()] = translation.get_language()
+        attrs[get_widget_language_attr()] = translation.get_language() 
         attrs['data-sitekey'] = self.site_key
+        if get_captcha_version() == 2:
+            attrs['data-api-endpoint'] = get_captcha_endpoint()
+        else:
+            attrs['data-puzzle-endpoint'] = get_captcha_endpoint()
+        attrs['data-start'] = get_start_mode()
         attrs[get_widget_field_name_attr()] = name
         attrs['class'] = 'frc-captcha'
         final_attrs = self.build_attrs(attrs)


### PR DESCRIPTION
## Summary

This PR adds support for **Friendly Captcha v2** verification and introduces a small set of new configuration options to make the integration more flexible.

## What changed

### v2 verification support
- Added proper support for **v2 verification requests**
- Updated request payload and headers to match the v2 API
- Added endpoint handling for v2 verification URLs
- Updated widget rendering to use the correct v2 endpoint attribute

### New optional configuration variables
This PR introduces optional settings to control core behavior:

- **`FRC_CAPTCHA_VERSION`**  
  Lets the integration switch between v1 and v2

- **`FRC_CAPTCHA_ENDPOINT`**  
  Allows choosing the endpoint region, e.g. `eu` or the default/global endpoint

- **`FRC_CAPTCHA_START_MODE`**  
  Lets you configure how the widget starts, e.g. `focus`, `auto`, or `none`

## Additional updates
- Adjusted utilities to resolve version-specific endpoints and payloads
- Updated tests to cover:
  - v1 and v2 version selection
  - endpoint resolution
  - v2 widget rendering
  - v2 verification success and failure cases
  - optional config behavior

## Validation
- Tested locally
- Verification was successful

## Result
- **Friendly Captcha v2 verification now works**
- The integration is more configurable and easier to adapt to different deployment setups
- Existing behavior remains supported through version-based configuration

## Notes
I also cleaned up the verification flow so that the plugin now consistently selects the correct payload, headers, and endpoint based on the configured FC version.